### PR TITLE
build: set local-scheme to no-local-version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]
 write_to = "confidence/_version.py"
+local_scheme = "no-local-version"
 
 [project]
 name = "confidence_openfeature_provider"


### PR DESCRIPTION
There was a [problem ](https://github.com/spotify/confidence-openfeature-provider-python/actions/runs/6184591535/job/16788534746)with the generated non-tagged version when uploading to test pypi.

The idea is that this should drop the "local version/sha stuff" at the end of the version and that it would work better.

Running `python -m setuptools_scm` gives:
```
0.1.1.dev3
```