### PR TITLE
feat!: bump python version >=3.9 and add async calls to open feature

### DIFF
--- a/.github/workflows/pull-requests.yaml
+++ b/.github/workflows/pull-requests.yaml
@@ -19,7 +19,7 @@ jobs:
     timeout-minutes: 10
     strategy:
       matrix:
-        container: [ "python:3.8", "python:3.9", "python:3.10", "python:3.11" ]
+        container: [ "python:3.9", "python:3.10", "python:3.11" ]
     container:
       image: ${{ matrix.container }}
 

--- a/confidence/openfeature_provider.py
+++ b/confidence/openfeature_provider.py
@@ -121,6 +121,21 @@ class ConfidenceOpenFeatureProvider(AbstractProvider):
             flag_metadata=details.flag_metadata,
         )
 
+    async def resolve_boolean_details_async(
+        self, flag_key, default_value, evaluation_context=None
+    ):
+        details = await self._confidence_with_context(
+            evaluation_context
+        ).resolve_boolean_details_async(flag_key, default_value)
+        return FlagResolutionDetails[bool](
+            value=details.value,
+            variant=details.variant,
+            reason=details.reason,
+            error_code=_to_openfeature_error_code(details.error_code),
+            error_message=details.error_message,
+            flag_metadata=details.flag_metadata,
+        )
+
     def resolve_float_details(
         self,
         flag_key: str,
@@ -130,6 +145,21 @@ class ConfidenceOpenFeatureProvider(AbstractProvider):
         details = self._confidence_with_context(
             evaluation_context
         ).resolve_float_details(flag_key, default_value)
+        return FlagResolutionDetails[float](
+            value=details.value,
+            variant=details.variant,
+            reason=details.reason,
+            error_code=_to_openfeature_error_code(details.error_code),
+            error_message=details.error_message,
+            flag_metadata=details.flag_metadata,
+        )
+
+    async def resolve_float_details_async(
+        self, flag_key, default_value, evaluation_context=None
+    ):
+        details = await self._confidence_with_context(
+            evaluation_context
+        ).resolve_float_details_async(flag_key, default_value)
         return FlagResolutionDetails[float](
             value=details.value,
             variant=details.variant,
@@ -157,6 +187,21 @@ class ConfidenceOpenFeatureProvider(AbstractProvider):
             flag_metadata=details.flag_metadata,
         )
 
+    async def resolve_integer_details_async(
+        self, flag_key, default_value, evaluation_context=None
+    ):
+        details = await self._confidence_with_context(
+            evaluation_context
+        ).resolve_integer_details_async(flag_key, default_value)
+        return FlagResolutionDetails[int](
+            value=details.value,
+            variant=details.variant,
+            reason=details.reason,
+            error_code=_to_openfeature_error_code(details.error_code),
+            error_message=details.error_message,
+            flag_metadata=details.flag_metadata,
+        )
+
     def resolve_string_details(
         self,
         flag_key: str,
@@ -175,6 +220,21 @@ class ConfidenceOpenFeatureProvider(AbstractProvider):
             flag_metadata=details.flag_metadata,
         )
 
+    async def resolve_string_details_async(
+        self, flag_key, default_value, evaluation_context=None
+    ):
+        details = await self._confidence_with_context(
+            evaluation_context
+        ).resolve_string_details_async(flag_key, default_value)
+        return FlagResolutionDetails[str](
+            value=details.value,
+            variant=details.variant,
+            reason=details.reason,
+            error_code=_to_openfeature_error_code(details.error_code),
+            error_message=details.error_message,
+            flag_metadata=details.flag_metadata,
+        )
+
     def resolve_object_details(
         self,
         flag_key: str,
@@ -184,6 +244,21 @@ class ConfidenceOpenFeatureProvider(AbstractProvider):
         details = self._confidence_with_context(
             evaluation_context
         ).resolve_object_details(flag_key, default_value)
+        return FlagResolutionDetails[Union[Object, List[Primitive]]](
+            value=details.value,
+            variant=details.variant,
+            reason=details.reason,
+            error_code=_to_openfeature_error_code(details.error_code),
+            error_message=details.error_message,
+            flag_metadata=details.flag_metadata,
+        )
+
+    async def resolve_object_details_async(
+        self, flag_key, default_value, evaluation_context=None
+    ):
+        details = await self._confidence_with_context(
+            evaluation_context
+        ).resolve_object_details_async(flag_key, default_value)
         return FlagResolutionDetails[Union[Object, List[Primitive]]](
             value=details.value,
             variant=details.variant,

--- a/confidence/openfeature_provider.py
+++ b/confidence/openfeature_provider.py
@@ -122,8 +122,8 @@ class ConfidenceOpenFeatureProvider(AbstractProvider):
         )
 
     async def resolve_boolean_details_async(
-        self, flag_key, default_value, evaluation_context=None
-    ):
+        self, flag_key: str, default_value: bool, evaluation_context: Optional[EvaluationContext] = None
+    ) -> FlagResolutionDetails[bool]:
         details = await self._confidence_with_context(
             evaluation_context
         ).resolve_boolean_details_async(flag_key, default_value)
@@ -155,8 +155,8 @@ class ConfidenceOpenFeatureProvider(AbstractProvider):
         )
 
     async def resolve_float_details_async(
-        self, flag_key, default_value, evaluation_context=None
-    ):
+        self, flag_key: str, default_value: float, evaluation_context: Optional[EvaluationContext] = None
+    ) -> FlagResolutionDetails[float]:
         details = await self._confidence_with_context(
             evaluation_context
         ).resolve_float_details_async(flag_key, default_value)
@@ -188,8 +188,8 @@ class ConfidenceOpenFeatureProvider(AbstractProvider):
         )
 
     async def resolve_integer_details_async(
-        self, flag_key, default_value, evaluation_context=None
-    ):
+        self, flag_key: str, default_value: int, evaluation_context: Optional[EvaluationContext] = None
+    ) -> FlagResolutionDetails[int]:
         details = await self._confidence_with_context(
             evaluation_context
         ).resolve_integer_details_async(flag_key, default_value)
@@ -221,8 +221,8 @@ class ConfidenceOpenFeatureProvider(AbstractProvider):
         )
 
     async def resolve_string_details_async(
-        self, flag_key, default_value, evaluation_context=None
-    ):
+        self, flag_key: str, default_value: str, evaluation_context: Optional[EvaluationContext] = None
+    ) -> FlagResolutionDetails[str]:
         details = await self._confidence_with_context(
             evaluation_context
         ).resolve_string_details_async(flag_key, default_value)
@@ -254,8 +254,8 @@ class ConfidenceOpenFeatureProvider(AbstractProvider):
         )
 
     async def resolve_object_details_async(
-        self, flag_key, default_value, evaluation_context=None
-    ):
+        self, flag_key: str, default_value: Union[Object, List[Primitive]], evaluation_context: Optional[EvaluationContext] = None
+    ) -> FlagResolutionDetails[Union[Object, List[Primitive]]]:
         details = await self._confidence_with_context(
             evaluation_context
         ).resolve_object_details_async(flag_key, default_value)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,12 +26,12 @@ classifiers = [
 ]
 keywords = []
 dependencies = [
-    "requests==2.32.3", 
-    "openfeature-sdk==0.4.2", 
+    "requests==2.32.3",
+    "openfeature-sdk==8.0.0", 
     "typing_extensions==4.9.0",
     "httpx==0.27.2"
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 
 [project.optional-dependencies]
 dev = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
 keywords = []
 dependencies = [
     "requests==2.32.3",
-    "openfeature-sdk==8.0.0", 
+    "openfeature-sdk==0.8.0", 
     "typing_extensions==4.9.0",
     "httpx==0.27.2"
 ]


### PR DESCRIPTION
Openfeature now supports async calls in python ([change-log](https://github.com/open-feature/python-sdk/blob/main/CHANGELOG.md#080-2025-02-11)). However, support for python 3.8 with the latest version.

Happy to write some unit tests in the next few days if we're happy to drop 3.8 support.