### PR TITLE
feat: add support for setting resolve timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,21 @@ confidence = root_confidence.with_context({"user_id": "some-user-id"})
 default_value = False
 flag_details = confidence.resolve_boolean_details("flag-name.property-name", default_value)
 print(flag_details)
+```
 
+### Configuration options
+
+The SDK can be configured with several options:
+
+```python
+from confidence.confidence import Confidence, Region
+
+# Configure timeout for network requests
+confidence = Confidence(
+    client_secret="CLIENT_TOKEN",
+    region=Region.EU,  # Optional: defaults to GLOBAL
+    timeout_ms=5000  # Optional: specify timeout in milliseconds for network requests (default: 10000ms)
+)
 ```
 
 ### Tracking events

--- a/confidence/errors.py
+++ b/confidence/errors.py
@@ -10,6 +10,7 @@ class ErrorCode(Enum):
     TARGETING_KEY_MISSING = "TARGETING_KEY_MISSING"
     INVALID_CONTEXT = "INVALID_CONTEXT"
     GENERAL = "GENERAL"
+    TIMEOUT = "TIMEOUT"
 
 
 class ConfidenceError(Exception):
@@ -31,9 +32,23 @@ class ConfidenceError(Exception):
         self.error_code = error_code
 
 
+class TimeoutError(ConfidenceError):
+    """
+    This exception should be raised when the request to the backend takes longer
+    than the timeout set in the client.
+    """
+
+    def __init__(self, error_message: typing.Optional[str] = None):
+        """
+        Constructor for the TimeoutError. The error code for this type of exception
+        is ErrorCode.TIMEOUT.
+        """
+        super().__init__(ErrorCode.TIMEOUT, error_message)
+
+
 class FlagNotFoundError(ConfidenceError):
     """
-    This exception should be raised when the provider cannot find a flag with the
+    This exception should be raised when the SDK cannot find a flag with the
     key provided by the user.
     """
 

--- a/confidence/flag_types.py
+++ b/confidence/flag_types.py
@@ -37,6 +37,7 @@ class Reason(StrEnum):
     SPLIT = "SPLIT"
     TARGETING_MATCH = "TARGETING_MATCH"
     UNKNOWN = "UNKNOWN"
+    TIMEOUT = "TIMEOUT"
 
 
 FlagMetadata = typing.Mapping[str, typing.Any]

--- a/confidence/openfeature_provider.py
+++ b/confidence/openfeature_provider.py
@@ -85,6 +85,8 @@ def _to_openfeature_error_code(
         return openfeature.exception.ErrorCode.GENERAL
     if error_code is ErrorCode.PARSE_ERROR:
         return openfeature.exception.ErrorCode.PARSE_ERROR
+    if error_code is ErrorCode.TIMEOUT:
+        return openfeature.exception.ErrorCode.GENERAL
     if error_code is ErrorCode.NOT_READY:
         return openfeature.exception.ErrorCode.PROVIDER_NOT_READY
 

--- a/demo.py
+++ b/demo.py
@@ -5,22 +5,25 @@ from confidence.confidence import Confidence
 
 
 async def get_flag():
-    root = Confidence("API_CLIENT")
+    root = Confidence("API CLIENT", timeout_ms=100)
     random_uuid = uuid.uuid4()
     uuid_string = str(random_uuid)
     confidence = root.with_context({"targeting_key": uuid_string})
-    confidence.with_context({"app": "python"}).track("navigate", {})
-    print("Tracked navigate event")
+    #confidence.with_context({"app": "python"}).track("navigate", {})
+    #print("Tracked navigate event")
 
-    value = confidence.resolve_string_details("hawkflag.color", "False")
-    print(f"Flag value: {value}")
+    details = confidence.resolve_string_details("hawkflag.color", "default")
+    print(f"Flag value: {details.value}")
+    print(f"Flag reason: {details.reason}")
+    print(f"Flag error code: {details.error_code}")
+    print(f"Flag error message: {details.error_message}")
 
 
 # Another asynchronous function that calls the first one
 async def main():
     await get_flag()
     print("Finished calling get_flag")
-    await asyncio.sleep(5)
+    await asyncio.sleep(1)
     print("Finished sleeping for 1 seconds")
 
 


### PR DESCRIPTION
# Add timeout support to Confidence SDK
This PR adds timeout configuration and improved error handling to the Confidence Python SDK:
## Changes
- Add configurable timeout for network requests (default: 10 seconds)
- Properly handle request timeouts with descriptive error messages
- Return default values with appropriate error codes when timeouts occur
- Improve error handling in flag resolution methods
- Add TIMEOUT to error codes and reasons
- Update documentation with timeout configuration examples

## Benefits
- Better reliability in high-latency environments
- More predictable behavior when network issues occur
- Improved developer experience with clear error messages
- Enhanced control over SDK behavior in production environments
- This change allows developers to configure shorter timeouts when needed, ensuring applications remain responsive even when the flag resolution service is experiencing delays.