### PR TITLE
fix: release using trusted publishing

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -77,6 +77,6 @@ jobs:
           .
 
       - name: pypi-publish
-        uses: pypa/gh-action-pypi-publish@v1.10.3
+        uses: pypa/gh-action-pypi-publish@v1.12.4
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -29,6 +29,11 @@ jobs:
     if: ${{ needs.release-please.outputs.release_created }}
     container:
       image: "python:3.11"
+    environment:
+      name: pypi
+      url: https://pypi.org/p/spotify-confidence-sdk
+    permissions:
+      id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
     steps:
       - name: Check out src from Git
         uses: actions/checkout@v4
@@ -78,5 +83,3 @@ jobs:
 
       - name: pypi-publish
         uses: pypa/gh-action-pypi-publish@v1.12.4
-        with:
-          password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
Following this: https://docs.pypi.org/trusted-publishers/using-a-publisher/