### PR TITLE
chore: remove container spec in release job

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -27,8 +27,6 @@ jobs:
     needs: release-please
     runs-on: ubuntu-latest
     if: ${{ needs.release-please.outputs.release_created }}
-    container:
-      image: "python:3.11"
     environment:
       name: pypi
       url: https://pypi.org/p/spotify-confidence-sdk


### PR DESCRIPTION
Last release build failed with this message:
```
/usr/local/bin/python3: can't open file '/home/runner/work/_actions/pypa/gh-action-pypi-publish/v1.12.4/create-docker-action.py': [Errno 2] No such file or directory
```

grasping at straws...