### PR TITLE
ci: drop caching of virtualenv's

### DIFF
--- a/.github/workflows/pull-requests.yaml
+++ b/.github/workflows/pull-requests.yaml
@@ -30,12 +30,6 @@ jobs:
           fetch-depth: 0 # this (and below) is needed to have setuptools_scm report the correct version
           fetch-tags: true
 
-      - name: Cache virtualenvironment
-        uses: actions/cache@v3
-        with:
-          path: ~/.venv
-          key: ${{ hashFiles('requirements.txt', 'requirements-dev.txt') }}
-
       - name: Upgrade pip
         run: pip install --upgrade pip
 

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -40,12 +40,6 @@ jobs:
           fetch-depth: 0 # this (and below) is needed to have setuptools_scm report the correct version
           fetch-tags: true
 
-      - name: Cache virtualenvironment
-        uses: actions/cache@v3
-        with:
-          path: ~/.venv
-          key: ${{ hashFiles('requirements.txt', 'requirements-dev.txt') }}
-
       - name: Upgrade pip
         run: pip install --upgrade pip
 


### PR DESCRIPTION
Gives errors in ci builds:
```
Error: Input required and not supplied: key
```