### PR TITLE
build(deps): update typing_extensions to flexible range

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ keywords = []
 dependencies = [
     "requests==2.32.4", 
     "openfeature-sdk==0.4.2", 
-    "typing_extensions==4.9.0",
+    "typing_extensions>=4.9.0,<5.0.0",
     "httpx==0.27.2",
     "protobuf==5.29.5"
 ]


### PR DESCRIPTION
Changed from pinned version 4.9.0 to range >=4.9.0,<5.0.0 to allow automatic updates within the 4.x series while maintaining backward compatibility.

🤖 Generated with [Claude Code](https://claude.ai/code)