### PR TITLE
fix(deps): introduce flexible protobuf version range

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     "openfeature-sdk==0.4.2", 
     "typing_extensions==4.9.0",
     "httpx==0.27.2",
-    "protobuf==5.29.5"
+    "protobuf>=5.29.5,<7.0.0"
 ]
 requires-python = ">=3.9"
 


### PR DESCRIPTION
Update protobuf dependency from fixed version 5.29.5 to range >=5.29.5,<7.0.0 to allow for more flexible dependency management while maintaining compatibility.

🤖 Generated with [Claude Code](https://claude.ai/code)