### PR TITLE
ci: declare minimum permissions on lint-pr-name workflow

### DIFF
--- a/.github/workflows/lint-pr-name.yaml
+++ b/.github/workflows/lint-pr-name.yaml
@@ -7,6 +7,10 @@ on:
       - edited
       - synchronize
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   main:
     name: Validate PR title


### PR DESCRIPTION
The `lint-pr-name` workflow runs on `pull_request_target`, which means the workflow's `GITHUB_TOKEN` defaults to the broader scopes used for pushes to the default branch, not the read-only scope used for `pull_request` from a fork.

This patch pins the token to the minimum it actually needs:

- `contents: read` so the third-party actions can still resolve refs.
- `pull-requests: write` so `marocchino/sticky-pull-request-comment` can post (and later delete) the lint-error comment.

The two actions invoked here (`amannn/action-semantic-pull-request`, `marocchino/sticky-pull-request-comment`) are third-party, so explicitly capping the token's authority narrows the blast radius if either is ever compromised (cf. CVE-2025-30066 / `tj-actions/changed-files`).

The style matches `pull-requests.yaml`, which already declares a workflow-level `permissions:` block.

No behavioural change, just a tighter token. Happy to adjust the layout if a per-job block is preferred.