### PR TITLE
ci: declare minimum permissions on workflow files

### DIFF
--- a/.github/workflows/lint-pr-name.yaml
+++ b/.github/workflows/lint-pr-name.yaml
@@ -7,6 +7,10 @@ on:
       - edited
       - synchronize
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   main:
     name: Validate PR title


### PR DESCRIPTION
## Summary
- Adds explicit workflow-level `permissions:` blocks to harden `GITHUB_TOKEN` scope
- `lint-pr-name.yaml` (runs on `pull_request_target`) gets `contents: read` + `pull-requests: write`
- `pull-requests.yaml` and `release-please.yaml` already had correct permissions

Motivated by CVE-2025-30066 — pinning permissions caps token authority if a third-party action is compromised.