### PR TITLE
fix(deps): relax httpx version pin to >=0.27.2,<1.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "requests>=2.33.1,<3.0.0",
     "openfeature-sdk==0.4.2", 
     "typing_extensions>=4.9.0,<5.0.0",
-    "httpx==0.27.2",
+    "httpx>=0.27.2,<1.0.0",
     "protobuf>=5.29.5,<7.0.0"
 ]
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary
- Relaxes `httpx` dependency from exact pin `==0.27.2` to `>=0.27.2,<1.0.0`
- Fixes compatibility with packages requiring newer httpx (e.g. `google-genai==2.0.0` needs `httpx>=0.28.1`)
- All 68 tests pass against httpx 0.28.1

## Test plan
- [x] Full test suite passes with httpx 0.28.1
- [x] Verified SDK only uses stable httpx APIs (`AsyncClient.post`, `TimeoutException`, `HTTPError`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)