### PR TITLE
fix: isolate context dict per Confidence instance to prevent shared mutable state

### DIFF
--- a/confidence/confidence.py
+++ b/confidence/confidence.py
@@ -111,7 +111,9 @@ class Confidence:
         self._apply_on_resolve = apply_on_resolve
         self._timeout_ms = timeout_ms
         self.logger = logger
-        self.async_client = async_client if async_client is not None else httpx.AsyncClient()
+        self.async_client = (
+            async_client if async_client is not None else httpx.AsyncClient()
+        )
         self._setup_logger(logger)
         self._custom_resolve_base_url = custom_resolve_base_url
         self._telemetry = Telemetry(__version__, disabled=disable_telemetry)

--- a/confidence/confidence.py
+++ b/confidence/confidence.py
@@ -77,8 +77,6 @@ class ResolveResult(object):
 
 
 class Confidence:
-    context: Dict[str, FieldType] = {}
-
     def put_context(self, key: str, value: FieldType) -> None:
         self.context[key] = value
 
@@ -103,16 +101,17 @@ class Confidence:
         custom_resolve_base_url: Optional[str] = None,
         timeout_ms: Optional[int] = DEFAULT_TIMEOUT_MS,
         logger: logging.Logger = logging.getLogger("confidence_logger"),
-        async_client: httpx.AsyncClient = httpx.AsyncClient(),
+        async_client: Optional[httpx.AsyncClient] = None,
         disable_telemetry: bool = False,
     ):
+        self.context: Dict[str, FieldType] = {}
         self._client_secret = client_secret
         self._region = region
         self._api_endpoint = region.endpoint()
         self._apply_on_resolve = apply_on_resolve
         self._timeout_ms = timeout_ms
         self.logger = logger
-        self.async_client = async_client
+        self.async_client = async_client if async_client is not None else httpx.AsyncClient()
         self._setup_logger(logger)
         self._custom_resolve_base_url = custom_resolve_base_url
         self._telemetry = Telemetry(__version__, disabled=disable_telemetry)

--- a/tests/test_confidence.py
+++ b/tests/test_confidence.py
@@ -589,6 +589,15 @@ class TestConfidence(unittest.IsolatedAsyncioTestCase):
             self.assertIsNone(result.variant)
             self.assertEqual(result.error_code, ErrorCode.TIMEOUT)
 
+    def test_context_is_isolated_per_instance(self):
+        a = Confidence(client_secret="test")
+        b = Confidence(client_secret="test")
+
+        a.put_context("user", "alice")
+
+        self.assertEqual(a.context, {"user": "alice"})
+        self.assertEqual(b.context, {})
+
     if __name__ == "__main__":
         unittest.main()
 


### PR DESCRIPTION
  # Description:

**Summary**

  - Moves `context` from a class-level attribute to an instance-level attribute initialized in `__init__`, preventing all
  `Confidence` instances from sharing the same dict
  - Changes `async_client` default from a mutable class-level default argument (httpx.AsyncClient()) to `None`, instantiating a
  fresh client per instance — fixing the same class of mutable-default-argument bug
  - Adds a regression test to assert that context mutations on one instance do not leak to another

 **Root cause**

`context: Dict[str, FieldType] = {}` was declared at class scope, making it a single shared dict across all instances. Any call to put_context on one `Confidence` object would silently mutate the context for every other instance in the same process. The same issue existed for `async_client`, which was evaluated once at class definition time and shared.

  Test plan - see [issue](https://github.com/spotify/confidence-sdk-python/issues/114): 

  - [x] test_context_is_isolated_per_instance passes — confirms the fix
  - [x] Existing test suite passes — no regressions in flag resolution or telemetry behavior

