### PR TITLE
chore: mark SDK as maintenance mode

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,7 @@
 # Contributing
 
+> **⚠️ This SDK is in maintenance mode.** New features and enhancements should target the [Confidence Resolver Python OpenFeature Provider](https://github.com/spotify/confidence-resolver/tree/main/openfeature-provider/python) instead. Only critical bug fixes will be accepted here.
+
 ## Getting Involved
 
 We welcome contributions and are happy to discuss ideas, answer questions, and help you get started.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # Python Confidence SDK
 
+> **⚠️ This SDK is in maintenance mode.**
+> We recommend migrating to the [Confidence Resolver Python OpenFeature Provider](https://github.com/spotify/confidence-resolver/tree/main/openfeature-provider/python), which offers better resilience and lower latency.
+>
+> This SDK will continue to receive critical bug fixes but no new features.
+
 This repo contains the [Confidence](https://confidence.spotify.com/) Python SDK and the Confidence OpenFeature provider. We recommend using the [OpenFeature Python SDK](https://github.com/open-feature/python-sdk) to access Confidence feature flags.
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,11 +16,12 @@ packages = {find = {exclude = ["demo"]}}
 [project]
 name = "spotify_confidence_sdk"
 dynamic = ["version"]
-description = "Confidence provider for the OpenFeature SDK"
+description = "[Maintenance mode] Confidence provider for the OpenFeature SDK — migrate to confidence-resolver"
 readme = "README.md"
 authors = [{ name = "Confidence team" }]
 license = { file = "LICENSE" }
 classifiers = [
+    "Development Status :: 7 - Inactive",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3"
 ]


### PR DESCRIPTION
## Summary
- Add maintenance mode banner to README and CONTRIBUTING
- Update pyproject.toml description and add `Development Status :: 7 - Inactive` classifier
- Redirect users to [confidence-resolver](https://github.com/spotify/confidence-resolver/tree/main/openfeature-provider/python)

🤖 Generated with [Claude Code](https://claude.com/claude-code)