### PR TITLE
ci: update release-please-action from v3 to v4.1.1

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -12,13 +12,12 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: google-github-actions/release-please-action@db8f2c60ee802b3748b512940dde88eabd7b7e01 # v3
+      - uses: google-github-actions/release-please-action@e4dc86ba9405554aeba3c6bb2d169500e7d3b4ee # v4.1.1
         id: release
         with:
-          command: manifest
           release-type: python
           token: ${{secrets.GITHUB_TOKEN}}
-          default-branch: main
+          target-branch: main
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
       release_tag_name: ${{ steps.release.outputs.tag_name }}


### PR DESCRIPTION
## Summary
- Update `google-github-actions/release-please-action` from v3 to v4.1.1
- Remove deprecated `command: manifest` input (v4 defaults to manifest mode)
- Rename `default-branch` to `target-branch`

Node.js 20 actions are deprecated starting June 16, 2026.

🤖 Generated with [Claude Code](https://claude.com/claude-code)